### PR TITLE
Fix android crash when a realm is unreachable

### DIFF
--- a/android/src/main/kotlin/xyz/juicebox/sdk/Client.kt
+++ b/android/src/main/kotlin/xyz/juicebox/sdk/Client.kt
@@ -182,7 +182,8 @@ class Client private constructor (
                         Native.httpClientRequestComplete(httpClient, response)
                     } catch (t: Throwable) {
                         Log.e("JuiceboxClient", "Failed to make http call", t)
-                        response.statusCode = -1
+                        // 0 not -1: Java short -1 panics in JNI i16 → u16 try_into conversion
+                        response.statusCode = 0
                         response.body = byteArrayOf()
                         response.headers = arrayOf()
                         Native.httpClientRequestComplete(httpClient, response)


### PR DESCRIPTION
## context
if one host fails (connectexception), the android http callback builds a fake error response and
hands it back to native. without that completing cleanly, the app dies and never finishes.

## previous fix

#13 (https://github.com/juicebox-systems/juicebox-sdk/pull/13) (eric) filled in missing fields
on the fake response (id, body, headers) so jni would not panic on null id.
but `statuscode = -1` was still there.

## why that was not enough

jni reads status as a java short (signed) and converts it to rust u16 with try_into().unwrap().
-1 is valid as a short but not as a non-negative u16, so unwrap still panics in native after the catch.

## this change
set statuscode = 0 instead of -1.
0 converts cleanly;
rust treats an invalid/non-success status as a network error for that realm so other realms can still succeed.

## test

• [x] block one realm host via custom DNS, enter pin → no crash;
• [x] block all realms → enter pin -> no crash;